### PR TITLE
Update Readme to show import path in addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ via `this` within the test callback:
 ```javascript
 import { moduleFor } from 'ember-qunit';
 import test from 'my-app/tests/ember-sinon-qunit/test';
+//import test from 'dummy/tests/ember-sinon-qunit/test'; => In case of addons
 
 moduleFor('route:foo', 'Unit | Route | foo');
 
@@ -51,6 +52,7 @@ loss of functionality. Or, you can import them both into the same test to be use
 ```javascript
 import { moduleFor, test } from 'ember-qunit';
 import sinonTest from 'my-app/tests/ember-sinon-qunit/test';
+//import sinonTest from 'dummy/tests/ember-sinon-qunit/test'; => In case of addons
 ```
 
 ## Contributing


### PR DESCRIPTION
Mentioned the import path of sinon in addons as comments in all examples so that new users don't miss out on it as they go through the readme.md.

Stumbled across this issue myself and noticed the issue so sent this PR :smile: 
Fixes #4 