### PR TITLE
Implement context testing across all variants of module tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-qunit": "^2.0.0",
     "ember-cli-release": "1.0.0-beta.1",
+    "ember-data": "2.5.3",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",

--- a/tests/acceptance/application-test.js
+++ b/tests/acceptance/application-test.js
@@ -1,0 +1,30 @@
+import { skip } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import assertSinonInTestContext from '../../tests/helpers/assert-sinon-in-test-context';
+import test from 'dummy/tests/ember-sinon-qunit/test';
+
+const fooValue = 42;
+
+moduleForAcceptance('Acceptance | application', {
+  beforeEach() {
+    this.foo = fooValue;
+  }
+});
+
+test('visiting /', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/');
+  });
+});
+
+assertSinonInTestContext(test);
+
+// Currently, the context of `moduleForAcceptance` is not shared by
+// ember-sinon-qunit's `test` context
+// (See: https://github.com/elwayman02/ember-sinon-qunit/issues/25#issuecomment-222022526)
+skip('preserving the context from the `beforeEach` hook', function (assert) {
+  assert.ok(this.foo);
+  assert.equal(this.foo, fooValue);
+});

--- a/tests/dummy/app/components/video-player.js
+++ b/tests/dummy/app/components/video-player.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+const { Component } = Ember;
+
+
+export default Component.extend({});

--- a/tests/dummy/app/models/user.js
+++ b/tests/dummy/app/models/user.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+
+const { computed } = Ember;
+
+
+export default Model.extend({
+  firstName: attr('string'),
+  lastName: attr('string'),
+
+  fullName: computed('firstName', 'lastName', function () {
+    return `${this.get('firstName')} ${this.get('lastName')}`;
+  })
+});

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+const { Route } = Ember;
+
+
+export default Route.extend({});

--- a/tests/helpers/assert-sinon-in-test-context.js
+++ b/tests/helpers/assert-sinon-in-test-context.js
@@ -1,0 +1,64 @@
+import Ember from 'ember';
+
+const { K: EmptyFunc, isPresent, typeOf } = Ember;
+
+const obj = {
+  foo: EmptyFunc,
+  bar: EmptyFunc,
+  baz: EmptyFunc
+};
+
+/**
+ * Performs a series of assertions for the presence of sinon functionality
+ * in whatever module variant that the `test` context is currently being
+ * brought into (e.g. `module`, `moduleFor`, `moduleForComponent`)
+ */
+export default function assertSinonInTestContext(test) {
+
+  test('brings spy() into test context', function (assert) {
+    assert.equal(typeOf(this.spy), 'function', 'spy exists');
+
+    const spy = this.spy(obj, 'foo');
+    obj.foo();
+
+    assert.ok(spy.calledOnce, 'spy registered call');
+  });
+
+  test('brings stub() into test context', function (assert) {
+    assert.equal(typeOf(this.stub), 'function', 'stub exists');
+
+    const stub = this.stub(obj, 'bar');
+    obj.bar();
+
+    assert.ok(stub.calledOnce, 'stub registered call');
+  });
+
+  test('brings mock() into test context', function (assert) {
+    assert.equal(typeOf(this.mock), 'function', 'mock exists');
+
+    const mock = this.mock(obj);
+    mock.expects('baz').once();
+    obj.baz();
+
+    mock.verify();
+  });
+
+  test('brings sandbox() into test context', function (assert) {
+    assert.equal(typeOf(this.sandbox), 'object', 'sandbox exists');
+    assert.equal(this.sandbox.injectInto, this, 'sandbox was injected into context');
+    const keys = this.sandbox.injectedKeys;
+    assert.equal(keys.length, 4, '4 keys were injected');
+    assert.equal(keys[0], 'spy', 'spy is injected');
+    assert.equal(keys[1], 'stub', 'stub is injected');
+    assert.equal(keys[2], 'mock', 'mock is injected');
+    assert.equal(keys[3], 'sandbox', 'sandbox is injected');
+  });
+
+  test('sinon sandbox cleans up after itself', function (assert) {
+    const spy = this.spy(obj, 'foo');
+    const stub = this.stub(obj, 'bar');
+
+    assert.ok(!spy.called, 'spy has no registered calls');
+    assert.ok(!stub.called, 'stub has no registered calls');
+  });
+}

--- a/tests/integration/components/video-player-component-test.js
+++ b/tests/integration/components/video-player-component-test.js
@@ -1,0 +1,21 @@
+import { moduleForComponent } from 'ember-qunit';
+import test from 'dummy/tests/ember-sinon-qunit/test';
+import hbs from 'htmlbars-inline-precompile';
+import assertSinonInTestContext from '../../helpers/assert-sinon-in-test-context';
+
+const fooValue = 42;
+
+moduleForComponent('video-player', 'Integration | Component | video player', {
+  integration: true,
+  beforeEach() {
+    this.foo = fooValue;
+  }
+});
+
+assertSinonInTestContext(test);
+
+test('preserving the context from the `beforeEach` hook', function (assert) {
+  debugger;
+  assert.ok(this.foo);
+  assert.equal(this.foo, fooValue);
+});

--- a/tests/unit/ember-sinon-qunit-test.js
+++ b/tests/unit/ember-sinon-qunit-test.js
@@ -1,14 +1,6 @@
-import Ember from 'ember';
 import { module, skip } from 'qunit';
 import test from 'dummy/tests/ember-sinon-qunit/test';
-
-const { K: EmptyFunc, isPresent, typeOf } = Ember;
-
-let obj = {
-  foo: EmptyFunc,
-  bar: EmptyFunc,
-  baz: EmptyFunc
-};
+import assertSinonInTestContext from '../helpers/assert-sinon-in-test-context';
 
 module('Unit | ember-sinon-qunit', {
   beforeEach() {
@@ -16,53 +8,11 @@ module('Unit | ember-sinon-qunit', {
   }
 });
 
-test('brings spy() into test context', function (assert) {
-  assert.equal(typeOf(this.spy), 'function', 'spy exists');
+assertSinonInTestContext(test);
 
-  const spy = this.spy(obj, 'foo');
-  obj.foo();
-
-  assert.ok(spy.calledOnce, 'spy registered call');
-});
-
-test('brings stub() into test context', function (assert) {
-  assert.equal(typeOf(this.stub), 'function', 'stub exists');
-
-  const stub = this.stub(obj, 'bar');
-  obj.bar();
-
-  assert.ok(stub.calledOnce, 'stub registered call');
-});
-
-test('brings mock() into test context', function (assert) {
-  assert.equal(typeOf(this.mock), 'function', 'mock exists');
-
-  const mock = this.mock(obj);
-  mock.expects('baz').once();
-  obj.baz();
-
-  mock.verify();
-});
-
-test('brings sandbox() into test context', function (assert) {
-  assert.equal(typeOf(this.sandbox), 'object', 'sandbox exists');
-  assert.equal(this.sandbox.injectInto, this, 'sandbox was injected into this');
-  const keys = this.sandbox.injectedKeys;
-  assert.equal(keys.length, 4, '4 keys were injected');
-  assert.equal(keys[0], 'spy', 'spy is injected');
-  assert.equal(keys[1], 'stub', 'stub is injected');
-  assert.equal(keys[2], 'mock', 'mock is injected');
-  assert.equal(keys[3], 'sandbox', 'sandbox is injected');
-});
-
-test('sinon sandbox cleans up after itself', function (assert) {
-  const spy = this.spy(obj, 'foo');
-  const stub = this.stub(obj, 'bar');
-
-  assert.ok(!spy.called, 'spy has no registered calls');
-  assert.ok(!stub.called, 'stub has no registered calls');
-});
-
+// Currently, the context of `module` is not shared by
+// ember-sinon-qunit's `test` context
+// (See: https://github.com/elwayman02/ember-sinon-qunit/issues/25#issuecomment-222022526)
 skip('does not destroy context from beforeEach', function (assert) {
   assert.ok(isPresent(this.foo), 'this.foo exists');
 });

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -1,0 +1,27 @@
+import { moduleForModel } from 'ember-qunit';
+import test from 'dummy/tests/ember-sinon-qunit/test';
+import assertSinonInTestContext from '../../helpers/assert-sinon-in-test-context';
+
+const fooValue = 42;
+
+moduleForModel('user', 'Unit | Model | user', {
+  // Specify the other units that are required for this test.
+  needs: [],
+  beforeEach() {
+    this.foo = fooValue;
+  }
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});
+
+assertSinonInTestContext(test);
+
+test('preserving the context from the `beforeEach` hook', function (assert) {
+  debugger;
+  assert.ok(this.foo);
+  assert.equal(this.foo, fooValue);
+});

--- a/tests/unit/routes/application-test.js
+++ b/tests/unit/routes/application-test.js
@@ -1,0 +1,26 @@
+import { moduleFor } from 'ember-qunit';
+import test from 'dummy/tests/ember-sinon-qunit/test';
+import assertSinonInTestContext from '../../helpers/assert-sinon-in-test-context';
+
+const fooValue = 42;
+
+moduleFor('route:application', 'Unit | Route | application', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+  beforeEach() {
+    this.foo = fooValue;
+  }
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});
+
+assertSinonInTestContext(test);
+
+test('preserving the context from the `beforeEach` hook', function (assert) {
+  debugger;
+  assert.ok(this.foo);
+  assert.equal(this.foo, fooValue);
+});


### PR DESCRIPTION
Because the way that the context of the `test` function differs across various `module` variants when they're used with `ember-sinon-qunit` (see #25 for a deeper discussion), this PR attempts to establish an architecture for testing that exhibits this behavior. 