### PR TITLE
Update to ember-cli-qunit-3 (fixes context assignment during `beforeEach`)

### DIFF
--- a/addon-test-support/test.js
+++ b/addon-test-support/test.js
@@ -2,13 +2,14 @@ import Ember from 'ember';
 import sinon from 'sinon';
 import QUnit from 'qunit';
 import { test as emberQUnitTest } from 'ember-qunit';
+import { isBlank } from 'ember-utils';
 
 sinon.expectation.fail = sinon.assert.fail = function (msg) {
-  QUnit.ok(false, msg);
+  QUnit.assert.ok(false, msg);
 };
 
 sinon.assert.pass = function (assertion) {
-  QUnit.ok(true, assertion);
+  QUnit.assert.ok(true, assertion);
 };
 
 sinon.config = {
@@ -22,11 +23,10 @@ sinon.config = {
 let ALREADY_FAILED = {};
 
 export default function test(testName, callback) {
-
   let sandbox;
   let wrapper = function () {
     let context = this;
-    if (Ember.isBlank(context)) {
+    if (isBlank(context)) {
       context = {};
     }
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^2.0.1",
-    "ember-cli-qunit": "^2.2.0",
+    "ember-cli-qunit": "^3.0.2",
     "ember-cli-release": "1.0.0-beta.2",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",

--- a/tests/acceptance/application-test.js
+++ b/tests/acceptance/application-test.js
@@ -1,4 +1,3 @@
-import { skip } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 import assertSinonInTestContext from '../../tests/helpers/assert-sinon-in-test-context';
 import test from 'ember-sinon-qunit/test-support/test';
@@ -21,10 +20,6 @@ test('visiting /', function(assert) {
 
 assertSinonInTestContext(test);
 
-// Currently, the context of `moduleForAcceptance` is not shared by
-// ember-sinon-qunit's `test` context
-// (See: https://github.com/elwayman02/ember-sinon-qunit/issues/25#issuecomment-222022526)
-skip('preserving the context from the `beforeEach` hook', function (assert) {
-  assert.ok(this.foo);
+test('preserving the context from the `beforeEach` hook', function (assert) {
   assert.equal(this.foo, fooValue);
 });

--- a/tests/integration/components/video-player-component-test.js
+++ b/tests/integration/components/video-player-component-test.js
@@ -14,6 +14,5 @@ moduleForComponent('video-player', 'Integration | Component | video player', {
 assertSinonInTestContext(test);
 
 test('preserving the context from the `beforeEach` hook', function (assert) {
-  assert.ok(this.foo);
   assert.equal(this.foo, fooValue);
 });

--- a/tests/unit/ember-sinon-qunit-test.js
+++ b/tests/unit/ember-sinon-qunit-test.js
@@ -1,14 +1,15 @@
-import { module, skip } from 'qunit';
-import { isPresent } from 'ember-utils';
+import { module } from 'qunit';
 import test from 'ember-sinon-qunit/test-support/test';
 import assertSinonInTestContext from '../helpers/assert-sinon-in-test-context';
 import Ember from 'ember';
 
+let fooValue = 42;
 let origMethod;
 let obj;
+
 module('Unit | ember-sinon-qunit', {
   beforeEach() {
-    this.foo = 'foo';
+    this.foo = fooValue;
 
     origMethod = () => {};
     obj = {
@@ -23,11 +24,8 @@ module('Unit | ember-sinon-qunit', {
 
 assertSinonInTestContext(test);
 
-// Currently, the context of `module` is not shared by
-// ember-sinon-qunit's `test` context
-// (See: https://github.com/elwayman02/ember-sinon-qunit/issues/25#issuecomment-222022526)
-skip('does not destroy context from beforeEach', function (assert) {
-  assert.ok(isPresent(this.foo), 'this.foo exists');
+test('does not destroy context from beforeEach', function (assert) {
+  assert.equal(this.foo, fooValue);
 });
 
 test('async with assert.async()', function (assert) {
@@ -63,4 +61,3 @@ test('async with Promise and assert.async()', function (assert) {
     });
   });
 });
-

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -21,6 +21,5 @@ test('it exists', function(assert) {
 assertSinonInTestContext(test);
 
 test('preserving the context from the `beforeEach` hook', function (assert) {
-  assert.ok(this.foo);
   assert.equal(this.foo, fooValue);
 });

--- a/tests/unit/routes/application-test.js
+++ b/tests/unit/routes/application-test.js
@@ -20,6 +20,5 @@ test('it exists', function(assert) {
 assertSinonInTestContext(test);
 
 test('preserving the context from the `beforeEach` hook', function (assert) {
-  assert.ok(this.foo);
   assert.equal(this.foo, fooValue);
 });


### PR DESCRIPTION
This PR upgrades us to the `3.x` version of QUnit (via `ember-cli-qunit`), and in doing so closes #25 (and #69, #71, and #74 from Greenkeeper) thanks to, as @rwjblue [mentioned](https://github.com/elwayman02/ember-sinon-qunit/issues/25#issuecomment-250257903), all test variants using the same `QUnit` framework context.

From everything I could tell, the only change required on our end is [not being able to rely on the direct usage of `QUnit.ok` anymore](https://github.com/elwayman02/ember-sinon-qunit/compare/master...BrianSipple:upgrade-to-ember-cli-qunit-3.x?expand=1#diff-5d53d3ae980fedb3cd40074111033394L7). If I'm missing something, though, please feel free to point it out 😄.