### PR TITLE
Fix poll function in IE9

### DIFF
--- a/addon-test-support/test.js
+++ b/addon-test-support/test.js
@@ -80,7 +80,7 @@ export default function test(testName, callback) {
           testTimeoutDeferred.resolve();
           resolve(data);
         } else {
-          setTimeout(poll, 10, resolve, reject);
+          setTimeout(() => poll(resolve, reject), 10);
         }
       };
 


### PR DESCRIPTION
IE9 does not support additional params for `setTimeout`, so `poll` would receive `resolve` and `reject` params as `undefined`.