### PR TITLE
Address `sinon.sandbox.create()` deprecation

### DIFF
--- a/addon-test-support/utils/config.js
+++ b/addon-test-support/utils/config.js
@@ -58,7 +58,7 @@ let wrapTest = (testName, callback, importedQunitFunc) => {
 
     let config = getConfig(sinon.config);
     config.injectInto = context;
-    sandbox = sinon.sandbox.create(config);
+    sandbox = sinon.createSandbox(config);
     sandbox.usingPromise(RSVP);
 
     // There are two ways to have an async test:


### PR DESCRIPTION
Sinon deprecated `sinon.sandbox.create()` and advises using `sinon.createSandbox()` instead.

> `sandbox.create()` is deprecated. Use default sandbox at `sinon.sandbox` or create new sandboxes with `sinon.createSandbox()`