### PR TITLE
Add additional sinon functions to the test context.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,23 +30,33 @@ Usage
 ------------------------------------------------------------------------------
 
 Import Ember-Sinon-QUnit's `test` method into your tests in place of Ember-QUnit's test. This creates a Sinon `sandbox`
-around that test via Sinon's `test` API. Then, you can access Sinon's `spy`, `stub`, `mock`, and `sandbox` methods
-via `this` within the test callback:
+around that test via Sinon's `test` API. Then, you can access the following Sinon functions via `this` within the test callback:
+* `spy`, 
+* `stub`, 
+* `mock`, 
+* `fake`,
+* `replace`
+* `replaceGetter`
+* `replaceSetter`
+* `sandbox`
 
 ```javascript
-import { moduleFor } from 'ember-qunit';
+import { module } from 'qunit';
 import test from 'ember-sinon-qunit/test-support/test';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:foo', 'Unit | Route | foo');
+module('Unit | Route | foo', function(hooks) {
+  setupTest(hooks);
 
-test('fooTransition action transitions to bar route', function (assert) {
-  const route = this.subject();
-  const stub = this.stub(route, 'transitionTo');
-  
-  route.send('fooTransition');
-  
-  assert.ok(stub.calledOnce, 'transitionTo was called once');
-  assert.ok(stub.calledWithExactly('bar'), 'bar was passed to transitionTo');
+  test('fooTransition action transitions to bar route', function (assert) {
+    let route = this.owner.lookup('route:foo');
+    const stub = this.stub(route, 'transitionTo');
+    
+    route.send('fooTransition');
+    
+    assert.ok(stub.calledOnce, 'transitionTo was called once');
+    assert.ok(stub.calledWithExactly('bar'), 'bar was passed to transitionTo');
+  });
 });
 ```
 
@@ -54,8 +64,9 @@ That's it! You can use this `test` method in place of all Ember-QUnit tests if y
 loss of functionality. Or, you can import them both into the same test to be used only when you need Sinon:
 
 ```javascript
-import { moduleFor, test } from 'ember-qunit';
-import sinonTest from 'ember-sinon-qunit/test-support/test';
+import { module } from 'qunit';
+import test from 'ember-sinon-qunit/test-support/test';
+import { setupTest } from 'ember-qunit';
 ```
 
 Contributing

--- a/addon-test-support/utils/config.js
+++ b/addon-test-support/utils/config.js
@@ -26,7 +26,7 @@ const commonConfig = function() {
 const DEFAULT_SINON_CONFIG = {
   injectIntoThis: true,
   injectInto: null,
-  properties: ["spy", "stub", "mock", "clock", "server", "requests"],
+  properties: ['spy', 'stub', 'mock', 'clock', 'server', 'requests'],
   useFakeTimers: true,
   useFakeServer: true
 };
@@ -46,7 +46,7 @@ let getConfig = (overrides = {}) => {
   }
 
   return config;
-}
+};
 
 let wrapTest = (testName, callback, importedQunitFunc) => {
   let sandbox;
@@ -60,6 +60,13 @@ let wrapTest = (testName, callback, importedQunitFunc) => {
     config.injectInto = context;
     sandbox = sinon.createSandbox(config);
     sandbox.usingPromise(RSVP);
+
+    // Sinon itself only injects the limited number of config properties above.
+    // We have to inject the others ourselves.
+    context.fake = sandbox.fake;
+    context.replace = sandbox.replace;
+    context.replaceGetter = sandbox.replaceGetter;
+    context.replaceSetter = sandbox.replaceSetter;
 
     // There are two ways to have an async test:
     // 1. return a thenable
@@ -126,6 +133,6 @@ let wrapTest = (testName, callback, importedQunitFunc) => {
     sandbox.restore();
     throw exception;
   }
-}
+};
 
 export { wrapTest, commonConfig };

--- a/tests/helpers/assert-sinon-in-test-context.js
+++ b/tests/helpers/assert-sinon-in-test-context.js
@@ -41,6 +41,58 @@ export default function assertSinonInTestContext(test) {
     mock.verify();
   });
 
+  test('brings fake() into test context', function (assert) {
+    assert.equal(typeOf(this.fake), 'function', 'fake exists');
+
+    const fake = this.fake.returns('paz');
+    const result = fake();
+
+    assert.ok(fake.calledOnce, 'fake registered the call');
+    assert.equal(result, 'paz');
+  });
+
+  test('brings replace() into test context', function (assert) {
+    assert.equal(typeOf(this.replace), 'function', 'replace exists');
+
+    const stub = this.stub();
+    this.replace(obj, 'baz', stub);
+    obj.baz();
+
+    assert.ok(stub.calledOnce, 'replaced() stub registered call');
+  });
+
+  test('brings replaceGetter() into test context', function (assert) {
+    assert.equal(typeOf(this.replaceGetter), 'function', 'replaceGetter exists');
+
+    const thing = {
+      get y() {
+        return 'yo';
+      }
+    };
+
+    const stub = this.stub().returns('oy');
+    this.replaceGetter(thing, 'y', stub);
+    thing.y;
+
+    assert.ok(stub.calledOnce, 'replacedGetter() stub registered call');
+  });
+
+  test('brings replaceSetter() into test context', function (assert) {
+    assert.equal(typeOf(this.replaceSetter), 'function', 'replaceSetter exists');
+
+    const thing = {
+      set y(val) {
+        //this._y = val;
+      }
+    };
+
+    const stub = this.stub();
+    this.replaceSetter(thing, 'y', stub);
+    thing.y = 1;
+
+    assert.ok(stub.calledOnce, 'replacedSetter() stub registered call');
+  });
+
   test('brings sandbox() into test context', function (assert) {
     assert.equal(typeOf(this.sandbox), 'object', 'sandbox exists');
     assert.equal(this.sandbox.injectInto, this, 'sandbox was injected into context');


### PR DESCRIPTION
I've updated the readme and the config to expose additional sinon functions on the test context (`this`). I updated the readme example to the new testing style. 
