### PR TITLE
Add `[skip netlify]` to commit messages generated by dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -11,4 +11,4 @@ update_configs:
           update_type: "all"
     version_requirement_updates: "increase_versions"
     commit_message:
-      prefix: "[skip ci]"
+      prefix: "[skip netlify]"


### PR DESCRIPTION
This will prevent previews from being deployed since this process is automated and the previews are never used.