### PR TITLE
Fixing fake-timers issue brought up by @andreyfel

### DIFF
--- a/addon-test-support/sinon-sandbox.ts
+++ b/addon-test-support/sinon-sandbox.ts
@@ -1,4 +1,5 @@
-import sinon, { SinonSandbox } from 'sinon';
+import sinon, { SinonFakeTimers, SinonSandbox } from 'sinon';
+import { FakeTimerInstallOpts } from '@sinonjs/fake-timers';
 
 let originalUseFakeTimers: SinonSandbox['useFakeTimers'];
 let clockToRestore: SinonSandbox['clock'] | null;
@@ -39,15 +40,15 @@ export function restoreSandbox() {
  */
 function patchUseFakeTimers(sandbox: SinonSandbox) {
   originalUseFakeTimers = sandbox.useFakeTimers;
-
-  sandbox.useFakeTimers = function () {
+  sandbox.useFakeTimers = function (
+    config?: number | Date | Partial<FakeTimerInstallOpts>
+  ): SinonFakeTimers {
     if (clockToRestore) {
       throw new Error(
         "You called sinon's useFakeTimers multiple times within the same test. This can result in unknown behavior."
       );
     }
-
-    const clock = originalUseFakeTimers.apply(sandbox);
+    const clock = originalUseFakeTimers.apply(sandbox, [config]);
 
     clockToRestore = clock;
 


### PR DESCRIPTION
@andreyfel brought up an issue with previous commit `I think omitting arguments here is a mistake as useFakeTimers is usually called with arguments`.  He is correct we do need to continue to pass through arguments; however we need to be more precise than using IArguments for typescript.  This diff attempts to do that

Tests:
all app tests pass
ember ts:precompile passes