### PR TITLE
adding new index.d.ts declaration file to the root of the types directory and added a typesVersions field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,11 +150,5 @@
       "tokenRef": "GITHUB_AUTH"
     }
   },
-  "typesVersions": {
-    "*": {
-      "*": [
-        "types/*"
-      ]
-    }
-  }
+  "types": "./index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -149,5 +149,12 @@
       "release": true,
       "tokenRef": "GITHUB_AUTH"
     }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "types/*"
+      ]
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -150,5 +150,5 @@
       "tokenRef": "GITHUB_AUTH"
     }
   },
-  "types": "./index.d.ts"
+  "types": "types/index.d.ts"
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,11 @@
+declare module 'ember-sinon-qunit' {
+  /**
+   * Allows for creating and restoring a global sinon sandbox per test. This is
+   * done via the `QUnit.testStart` and `QUnit.testDone` methods.
+   *
+   * @export
+   * @param {Object} An object containing optional options
+   * @public
+   */
+  export default function setupSinon(testEnvironment?: QUnit): void;
+}


### PR DESCRIPTION
Adding a new index.d.ts declaration file delcaring the ember-sinon-qunit module and updating package.json to include typesversions field.  The hope is that this commit will allow emit types when `import setupSinon from 'ember-sinon-qunit'`

All tests pass
ember ts:precompile emits no errors