### PR TITLE
chore: ember-qunit 8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ To use, import the setup method into your `tests/test-helper.js` file and execut
 ```js
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+import * as QUnit from 'qunit';
 import Application from '../app';
 import config from '../config/environment';
 import setupSinon from 'ember-sinon-qunit';
 
 setApplication(Application.create(config.APP));
 
-setupSinon();
+setupSinon(QUnit);
 
 start();
 ```

--- a/addon/addon-test-support/index.ts
+++ b/addon/addon-test-support/index.ts
@@ -1,5 +1,4 @@
 import { createSandbox, restoreSandbox } from './sinon-sandbox';
-import * as QUnit from 'qunit';
 
 /**
  * Allows for creating and restoring a global sinon sandbox per test. This is
@@ -9,7 +8,7 @@ import * as QUnit from 'qunit';
  * @param {Object} An object containing optional options
  * @public
  */
-export default function setupSinon(testEnvironment = QUnit) {
+export default function setupSinon(testEnvironment: any) {
   testEnvironment.testStart(createSandbox);
   testEnvironment.testDone(restoreSandbox);
 }

--- a/addon/index.d.ts
+++ b/addon/index.d.ts
@@ -1,1 +1,1 @@
-export default function setupSinon(testEnvironment?: QUnit): void;
+export default function setupSinon(testEnvironment): void;

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -84,7 +84,7 @@
     "ember-data": "^5.3.0",
     "ember-load-initializers": "^2.1.2",
     "ember-page-title": "^8.0.0",
-    "ember-qunit": "^7.0.0",
+    "ember-qunit": "^8.0.1",
     "ember-resolver": "^11.0.1",
     "ember-sinon-qunit": "7.2.0",
     "ember-source": "~5.3.0",


### PR DESCRIPTION
## Chore

### Fix compatibility with `ember-qunit` v8

When using `ember-qunit@8.0.1` and this package, we had following errors when running tests
```
Uncaught Error: QUnit has already been defined.
```

Removing the code `import * as QUnit from 'qunit';` in `addon/addon-test-support/index.ts` solves the issue, but it force people consuming this repo to call `setupSinon` passing it `QUnit` parameter in `./tests/test-helper.js`
```
import * as QUnit from 'qunit';

setupSinon(QUnit);
```

See https://github.com/elwayman02/ember-sinon-qunit/issues/885