### PR TITLE
Add sinon v18 to peerDependencies

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -86,7 +86,7 @@
   "peerDependencies": {
     "ember-source": ">=3.28.0",
     "qunit": "^2.0.0",
-    "sinon": "^15.0.3 || ^16.0.0 || ^17.0.0"
+    "sinon": ">=15.0.3"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
sinon v18 was release a month ago https://www.npmjs.com/package/sinon?activeTab=versions

This change allows package managers to properly install and handle that version when `ember-sinon-qunit` is also used